### PR TITLE
update some a11y issues

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,22 +1,24 @@
-<!DOCTYPE html>
+<!DOCTYPE html lang="en">
 <head>
   <title>Digitapes</title>
   <link rel="stylesheet" type="text/css" href="style.css">
   <link rel="icon" href="favicon.ico" type="image/x-icon">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />   
+  <meta name="description" content="Open source personal media system" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Ubuntu:ital,wght@0,300;0,400;0,500;0,700;1,300;1,400;1,500;1,700&display=swap" rel="stylesheet">
   <!-- opengraph -->
-  <meta property="og:title" content="Open source personal media system" />
+  <meta property="og:title" content="Digitapes" />
+  <meta property="og:description" content="Open source personal media system" />
   <meta property="og:type" content="website" />
   <meta property="og:image" content="https://digitapes.app/how-marketing.png" />
   <meta property="og:url" content="https://digitapes.app" />
 
 </head>
 <body>
-  <img src="how-marketing.png"></img>
+  <img src="how-marketing.png" alt="flow of how digital assets are transformed by the application"></img>
   <div class="center">
     <p>Digitapes is an open-source, open-design, personal media system to 
     protect and cherish your favourite memories.</p>


### PR DESCRIPTION
- add a meta description for screen readers
- add a lang attribute so screen readers pick the correct language
- add img alt tags for screen readers
- update og:title to be the title, and add og:description to be a description

lighthouse audit of current site these issues came from
<img width="791" alt="Screenshot 2024-09-09 at 09 51 29" src="https://github.com/user-attachments/assets/757b047c-6122-4c52-afef-16041f674f99">
